### PR TITLE
Update youtube-transcript-api and test

### DIFF
--- a/rapidapi_transcript.py
+++ b/rapidapi_transcript.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import json
+import requests
+
+# Accept RAPIDAPI_KEY or X_RAPIDAPI_KEY from environment
+RAPID_KEY = os.getenv("RAPIDAPI_KEY") or os.getenv("X_RAPIDAPI_KEY")
+if not RAPID_KEY:
+	print("Missing RAPIDAPI_KEY or X_RAPIDAPI_KEY in environment", file=sys.stderr)
+	sys.exit(2)
+
+VIDEO_URL = sys.argv[1] if len(sys.argv) > 1 else "https://youtu.be/OVosXx5lXmw"
+API_URL = "https://youtube-transcription-api-and-youtube-translation-api.p.rapidapi.com/transcribe"
+
+headers = {
+	"content-type": "application/json",
+	"X-RapidAPI-Key": RAPID_KEY,
+}
+
+payload = {"url": VIDEO_URL}
+
+try:
+	resp = requests.post(API_URL, headers=headers, json=payload, timeout=90)
+	if resp.status_code != 200:
+		print(f"HTTP {resp.status_code}: {resp.text}", file=sys.stderr)
+		sys.exit(1)
+	data = resp.json()
+	# Try common fields
+	transcript = data.get("transcription") or data.get("transcript") or data.get("data") or data
+	if isinstance(transcript, (list, dict)):
+		print(json.dumps(transcript, ensure_ascii=False, indent=2))
+	else:
+		print(transcript)
+except Exception as e:
+	print(f"ERROR: {type(e).__name__}: {e}", file=sys.stderr)
+	sys.exit(3)

--- a/stt_elevenlabs.py
+++ b/stt_elevenlabs.py
@@ -1,0 +1,83 @@
+import argparse
+import os
+from typing import Optional, Tuple
+
+from elevenlabs import ElevenLabs
+
+
+def transcribe(
+    *,
+    path: Optional[str],
+    cloud_url: Optional[str],
+    model: str = "scribe_v1",
+    lang: Optional[str] = None,
+    diarize: bool = True,
+    tag_events: bool = True,
+    multi_channel: bool = False,
+) -> Tuple[str, object]:
+    """
+    Transcribe audio/video using ElevenLabs Speech-to-Text.
+
+    Returns a tuple of (plain_text, raw_response_model).
+    """
+    client = ElevenLabs(api_key=os.getenv("ELEVENLABS_API_KEY"))
+    if client is None:
+        raise RuntimeError("Missing ELEVENLABS_API_KEY in environment")
+
+    kwargs = dict(
+        model_id=model,
+        language_code=lang if lang else None,
+        diarize=diarize,
+        tag_audio_events=tag_events,
+        use_multi_channel=multi_channel,
+    )
+
+    if cloud_url:
+        response = client.speech_to_text.convert(cloud_storage_url=cloud_url, **kwargs)
+    elif path:
+        with open(path, "rb") as file_handle:
+            response = client.speech_to_text.convert(file=file_handle, **kwargs)
+    else:
+        raise ValueError("Provide either a local --file or a public cloud --url")
+
+    # Response union may be a chunk model or multichannel model.
+    if hasattr(response, "transcripts") and isinstance(getattr(response, "transcripts"), list):
+        texts = [getattr(t, "text", "") for t in response.transcripts]
+        text = "\n".join([t for t in texts if t])
+    else:
+        text = getattr(response, "text", str(response))
+
+    return text, response
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Transcribe audio/video using ElevenLabs STT")
+    parser.add_argument("--file", help="Path to local audio/video file")
+    parser.add_argument("--url", help="Public cloud storage URL to media file (S3/R2/GCS presigned URL)")
+    parser.add_argument("--model", default="scribe_v1", help="Model ID to use (default: scribe_v1)")
+    parser.add_argument("--lang", help="ISO-639-1/3 language code, e.g. eng; defaults to auto-detect")
+    parser.add_argument("--no-diarize", action="store_true", help="Disable speaker diarization")
+    parser.add_argument("--no-tag-events", action="store_true", help="Disable tagging audio events like (laughter)")
+    parser.add_argument("--multi-channel", action="store_true", help="Enable multi-channel transcription")
+    parser.add_argument("--out", help="Optional path to save transcript text")
+    args = parser.parse_args()
+
+    text, _ = transcribe(
+        path=args.file,
+        cloud_url=args.url,
+        model=args.model,
+        lang=args.lang,
+        diarize=not args.no_diarize,
+        tag_events=not args.no_tag_events,
+        multi_channel=args.multi_channel,
+    )
+
+    if args.out:
+        os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write(text)
+    print(text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add `stt_elevenlabs.py` script to transcribe audio/video using ElevenLabs Speech-to-Text.

This script provides an alternative for generating transcripts when direct YouTube API access is blocked, allowing transcription of local audio files or public cloud URLs via ElevenLabs.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ccf246d-8366-4acf-a378-cd98a1340ff1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ccf246d-8366-4acf-a378-cd98a1340ff1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

