### PR TITLE
Integrate rapidapi youtube transcript retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ CLI
 Environment
 - `OPENAI_API_KEY` for LLM image prompts and scripts
 - `ELEVENLABS_API_KEY` for TTS
+- `RAPIDAPI_KEY` for YouTube transcript retrieval (RapidAPI: youtube-transcriptor)
 - Optional overrides:
   - `OPENAI_CHAT_MODEL`, `OPENAI_SCENE_MODEL`
   - `OPENAI_IMAGE_MODEL`, `OPENAI_IMAGE_SIZE`, `OPENAI_IMAGE_QUALITY`

--- a/example.env
+++ b/example.env
@@ -5,3 +5,6 @@ YOUTUBE_CREDENTIALS_DIR=
 # Optional overrides
 # PROMPT=
 
+# RapidAPI (used for YouTube transcript retrieval)
+RAPIDAPI_KEY=
+


### PR DESCRIPTION
Implement RapidAPI as the primary YouTube transcript retrieval method, making `youtube_transcript_api` an optional fallback and requiring a `RAPIDAPI_KEY`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4b455d2-6463-4e5d-99b7-5f94f14f0b63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4b455d2-6463-4e5d-99b7-5f94f14f0b63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

