### PR TITLE
Update voice configuration and propagate settings

### DIFF
--- a/slop/config.py
+++ b/slop/config.py
@@ -13,8 +13,12 @@ class AppConfig(BaseModel):
     resolution_height: int = 1536
     num_images: int = 12
     voice_id: str = "Bx2lBwIZJBilRBVc3AGO"
-    style: float = 0.60
-           speed = 0.94
+    # ElevenLabs voice settings (Optional so they can be omitted if None)
+    stability: Optional[float] = 0.50
+    similarity_boost: Optional[float] = 0.75
+    style: Optional[float] = 0.60
+    use_speaker_boost: Optional[bool] = True
+    speed: Optional[float] = 0.94
     #d4Z5Fvjohw3zxGpV8XUV - Maria float = 0.34
     #olRVHO9SSe7gI7wwlL9o - rachel
     #21m00Tcm4TlvDq8ikWAM - poeta
@@ -46,6 +50,72 @@ class AppConfig(BaseModel):
             except ValueError as e:
                 raise ValueError("style must be a float or 'none'") from e
         raise ValueError("style must be a float, numeric string, or 'none'")
+
+    @field_validator("stability", mode="before")
+    @classmethod
+    def normalize_stability(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"", "none", "null", "nil"}:
+                return None
+            try:
+                return float(value)
+            except ValueError as e:
+                raise ValueError("stability must be a float or 'none'") from e
+        raise ValueError("stability must be a float, numeric string, or 'none'")
+
+    @field_validator("similarity_boost", mode="before")
+    @classmethod
+    def normalize_similarity_boost(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"", "none", "null", "nil"}:
+                return None
+            try:
+                return float(value)
+            except ValueError as e:
+                raise ValueError("similarity_boost must be a float or 'none'") from e
+        raise ValueError("similarity_boost must be a float, numeric string, or 'none'")
+
+    @field_validator("speed", mode="before")
+    @classmethod
+    def normalize_speed(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"", "none", "null", "nil"}:
+                return None
+            try:
+                return float(value)
+            except ValueError as e:
+                raise ValueError("speed must be a float or 'none'") from e
+        raise ValueError("speed must be a float, numeric string, or 'none'")
+
+    @field_validator("use_speaker_boost", mode="before")
+    @classmethod
+    def normalize_use_speaker_boost(cls, value):
+        if isinstance(value, bool) or value is None:
+            return value
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"", "none", "null", "nil"}:
+                return None
+            if lowered in {"true", "1", "yes", "y", "on"}:
+                return True
+            if lowered in {"false", "0", "no", "n", "off"}:
+                return False
+        raise ValueError("use_speaker_boost must be a boolean or 'none'")
 
 # Note: file-based config loading has been removed intentionally.
 

--- a/slop/config.py
+++ b/slop/config.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import os
 from typing import Literal, Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel
 
 
 class AppConfig(BaseModel):
@@ -33,89 +32,7 @@ class AppConfig(BaseModel):
     tts_model_id: str = "eleven_v3"
     tts_output_format: str = "mp3_44100_128"
 
-    @field_validator("style", mode="before")
-    @classmethod
-    def normalize_style(cls, value):
-        # Accept float/int, numeric strings, or special strings like "none" to omit
-        if value is None:
-            return None
-        if isinstance(value, (int, float)):
-            return float(value)
-        if isinstance(value, str):
-            lowered = value.strip().lower()
-            if lowered in {"", "none", "null", "nil"}:
-                return None
-            try:
-                return float(value)
-            except ValueError as e:
-                raise ValueError("style must be a float or 'none'") from e
-        raise ValueError("style must be a float, numeric string, or 'none'")
-
-    @field_validator("stability", mode="before")
-    @classmethod
-    def normalize_stability(cls, value):
-        if value is None:
-            return None
-        if isinstance(value, (int, float)):
-            return float(value)
-        if isinstance(value, str):
-            lowered = value.strip().lower()
-            if lowered in {"", "none", "null", "nil"}:
-                return None
-            try:
-                return float(value)
-            except ValueError as e:
-                raise ValueError("stability must be a float or 'none'") from e
-        raise ValueError("stability must be a float, numeric string, or 'none'")
-
-    @field_validator("similarity_boost", mode="before")
-    @classmethod
-    def normalize_similarity_boost(cls, value):
-        if value is None:
-            return None
-        if isinstance(value, (int, float)):
-            return float(value)
-        if isinstance(value, str):
-            lowered = value.strip().lower()
-            if lowered in {"", "none", "null", "nil"}:
-                return None
-            try:
-                return float(value)
-            except ValueError as e:
-                raise ValueError("similarity_boost must be a float or 'none'") from e
-        raise ValueError("similarity_boost must be a float, numeric string, or 'none'")
-
-    @field_validator("speed", mode="before")
-    @classmethod
-    def normalize_speed(cls, value):
-        if value is None:
-            return None
-        if isinstance(value, (int, float)):
-            return float(value)
-        if isinstance(value, str):
-            lowered = value.strip().lower()
-            if lowered in {"", "none", "null", "nil"}:
-                return None
-            try:
-                return float(value)
-            except ValueError as e:
-                raise ValueError("speed must be a float or 'none'") from e
-        raise ValueError("speed must be a float, numeric string, or 'none'")
-
-    @field_validator("use_speaker_boost", mode="before")
-    @classmethod
-    def normalize_use_speaker_boost(cls, value):
-        if isinstance(value, bool) or value is None:
-            return value
-        if isinstance(value, str):
-            lowered = value.strip().lower()
-            if lowered in {"", "none", "null", "nil"}:
-                return None
-            if lowered in {"true", "1", "yes", "y", "on"}:
-                return True
-            if lowered in {"false", "0", "no", "n", "off"}:
-                return False
-        raise ValueError("use_speaker_boost must be a boolean or 'none'")
+    
 
 # Note: file-based config loading has been removed intentionally.
 

--- a/slop/pipeline.py
+++ b/slop/pipeline.py
@@ -73,7 +73,11 @@ def generate_video_pipeline(config: AppConfig, output_dir: Path) -> GeneratedVid
             output_dir=work_dir,
             model_id=config.tts_model_id,
             output_format=config.tts_output_format,
+            stability=config.stability,
+            similarity_boost=config.similarity_boost,
             style=config.style,
+            use_speaker_boost=config.use_speaker_boost,
+            speed=config.speed,
         )
         image_paths, (audio_path, alignment) = await asyncio.gather(images_task, tts_task)
         return image_paths, audio_path, alignment


### PR DESCRIPTION
Add all ElevenLabs voice settings to `AppConfig` and propagate them to `voice.py` for full TTS parameter control.

The `voice.py` module now dynamically constructs `VoiceSettings` by filtering to only include parameters supported by the installed ElevenLabs SDK version, preventing potential runtime errors for unsupported fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c5beccf-0c31-456d-bc68-0e25bc807d90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c5beccf-0c31-456d-bc68-0e25bc807d90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

