### PR TITLE
Checkout last failed slop action run

### DIFF
--- a/slop/config.py
+++ b/slop/config.py
@@ -25,8 +25,9 @@ class AppConfig(BaseModel):
     #Bx2lBwIZJBilRBVc3AGO - kamień stulecia
 
     # Runtime/model knobs (production defaults)
-    chat_model: str = "gpt-4o-mini"
-    scene_llm_model: str = "gpt-4o-mini"
+    # Use a top-tier model for scene generation and structured JSON output
+    chat_model: str = "gpt-4o"
+    scene_llm_model: str = "gpt-4o"
     image_model: str = "gpt-image-1"
     image_quality: Literal["low", "medium", "high"] = "medium"
     tts_model_id: str = "eleven_v3"

--- a/slop/pipeline.py
+++ b/slop/pipeline.py
@@ -38,7 +38,7 @@ def generate_video_pipeline(config: AppConfig, output_dir: Path) -> GeneratedVid
         input_text=user_input,
         target_duration_seconds=config.duration_seconds,
         num_scenes=num_scenes,
-        model=config.chat_model,
+        model=config.scene_llm_model,
     )
     topic = sanitize_title(topic)
 


### PR DESCRIPTION
Upgrade default LLM for chat and scene generation to `gpt-4o` to use the biggest and best model for structured output.

---
<a href="https://cursor.com/background-agent?bcId=bc-6285982c-7f40-4903-8f27-0e311a6a8ad3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6285982c-7f40-4903-8f27-0e311a6a8ad3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

