### PR TITLE
Update reaction-generate-and-upload github action

### DIFF
--- a/.github/workflows/reaction-generate-and-upload.yml
+++ b/.github/workflows/reaction-generate-and-upload.yml
@@ -44,14 +44,8 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Run generator if new video detected (YouTube + Drive)
-        run: |
-          uv run --python 3.11 slop generate-from-channel-if-new \
-            --channel-handle "@SwaruuOficial" \
-            --credentials-dir ./.youtube \
-            --output-dir outputs \
-            --upload \
-            --drive-upload
+      - name: Generate reaction video from latest channel upload
+        run: uv run --python 3.11 slop generate-reaction
 
 
       - name: Upload artifact (latest video)


### PR DESCRIPTION
Update `reaction-generate-and-upload` GitHub action to use the current `slop generate-reaction` CLI command because the previous command and flags are unsupported.

---
<a href="https://cursor.com/background-agent?bcId=bc-2aa6f068-0f9e-409d-9e2d-ae8ec2d790ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2aa6f068-0f9e-409d-9e2d-ae8ec2d790ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

